### PR TITLE
Fix general_math_ev3 so that it doesn't escape % when it already is

### DIFF
--- a/macros/PGbasicmacros.pl
+++ b/macros/PGbasicmacros.pl
@@ -1713,7 +1713,7 @@ sub general_math_ev3 {
 	my $mode = shift || "inline";
 
 	$in = FEQ($in); # Format EQuations
-	$in =~ s/%/\\%/g; # avoid % becoming TeX comments
+	$in =~ s/((^|[^\\])(\\\\)*)%/\1\\%/g; # avoid % becoming TeX comments (unless already escaped)
 
 	## remove leading and trailing spaces so that HTML mode will
 	## not include unwanted spaces as per Davide Cervone.
@@ -1721,7 +1721,7 @@ sub general_math_ev3 {
 	$in =~ s/\s+$//;
 	## If it ends with a backslash, there should be another space
 	## at the end
-	if($in =~ /\\$/) { $in .= ' ';} 
+	if ($in =~ /(^|[^\\])(\\\\)*\\$/) {$in .= ' '}
 
 	# some modes want the delimiters, some don't
 	my $in_delim = $mode eq "inline"


### PR DESCRIPTION
The `general_math_ev3` function manipulates the TeX string that it receives, and (among other things), it puts backslashes in front of percent signs.  This "fixes up" bad TeX entered by problem authors, but it also messes up good TeX created by MathObjects.

This patch prevents the escaping of `%` when it already is escaped (i.e. is preceded by an even, possibly 0, number of backslashes).

A test case for this is:

```
DOCUMENT();

loadMacros(
  "PGstandard.pl",
  "PGML.pl",
);

BEGIN_PGML
[`10%`] and [`10\%`]
END_PGML

BEGIN_TEXT
\(10%\) and \(10\%\)
END_TEXT

ENDDOCUMENT();
```

Without the patch, it will produce two copies of `10% and 10`, and with the patch, it should be two copies of `10% and 10%`.

My own feeling is that the code that puts out the proper math for the current displayMode should be factored out so that it can be called _without_ having such modifications made to it.  Math that is already properly formatted may be damaged (as in the case of the percent), and currently there is no way to avoid this (other than to modify the math so that it doesn't match the patterns).  There should be a way to get math output that is unmodified.
