### PR TITLE
Fix for https://github.com/openwebwork/pg/pull/620 so it works regardless of where the typeError gets triggered in the matrix

### DIFF
--- a/lib/Value/AnswerChecker.pm
+++ b/lib/Value/AnswerChecker.pm
@@ -582,6 +582,7 @@ sub ans_collect {
   my @array = (); my $data = [$self->value]; my $errors = []; my $OK = 1;
   if ($self->{ColumnVector}) {foreach my $x (@{$data}) {$x = [$x]}}
   $data = [$data] unless ref($data->[0]) eq 'ARRAY';
+  my $sawTypeError = 0;
   foreach my $i (0..$rows-1) {
     my @row = (); my $entry;
     foreach my $j (0..$cols-1) {
@@ -591,15 +592,15 @@ sub ans_collect {
 	$entry = $ans->{original_student_ans};
 	$ans->{student_formula} = $ans->{student_value} = undef unless $entry =~ m/\S/;
       }
-      $ans->{typeError} = 0;
       my $result = $data->[$i][$j]->cmp(@ans_cmp_defaults)->evaluate($entry);
       $OK &= entryCheck($result,$blank);
-      $ans->{typeError} = 1 if $result->{typeError};
+      $sawTypeError |= $result->{typeError};
       push(@row,$result->{student_formula});
       entryMessage($result->{ans_message},$errors,$i,$j,$rows,$cols);
     }
     push(@array,[@row]);
   }
+  $ans->{typeError} = $sawTypeError;
   $ans->{student_formula} = [@array];
   $ans->{ans_message} = $ans->{error_message} = "";
   if (scalar(@{$errors})) {


### PR DESCRIPTION
Set `$ans->{typeError}` for matrices based on whether any typeError was seen in the double loop.